### PR TITLE
chore: release

### DIFF
--- a/yaair/CHANGELOG.md
+++ b/yaair/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.2.0...yaair-v0.3.0) - 2026-05-07
+
+### Other
+
+- use PAT for opening PR so that workflows will run
+
 ## [0.2.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.1.0...yaair-v0.2.0) - 2026-04-07
 
 ### Fixed

--- a/yaair/Cargo.toml
+++ b/yaair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaair"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Nicolas Farabegoli <nicolas.farabegoli@gmail.com>"

--- a/yaair_serde/CHANGELOG.md
+++ b/yaair_serde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.2.0...yaair_serde-v0.2.1) - 2026-05-07
+
+### Other
+
+- use PAT for opening PR so that workflows will run
+
 ## [0.2.0](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.1.0...yaair_serde-v0.2.0) - 2026-04-07
 
 ### Fixed

--- a/yaair_serde/Cargo.toml
+++ b/yaair_serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaair_serde"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
     "Nicolas Farabegoli <nicolas.farabegoli@gmail.com>"
@@ -13,7 +13,7 @@ name = "gradient"
 path = "../examples/gradient.rs"
 
 [dependencies]
-yaair = { path = "../yaair", version = "0.2.0" }
+yaair = { path = "../yaair", version = "0.3.0" }
 serde = { version = "1.0.227" }
 serde_json = { version = "1.0.145" }
 


### PR DESCRIPTION



## 🤖 New release

* `yaair`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `yaair_serde`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

### ⚠ `yaair` breaking changes

```text
--- failure trait_allows_fewer_generic_type_params: trait now allows fewer generic type parameters ---

Description:
A trait now allows fewer generic type parameters than it used to. Uses of this trait that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_allows_fewer_generic_type_params.ron

Failed in:
  trait Network allows 2 -> 1 generic types in /tmp/.tmp3Yuxpk/yaair/yaair/src/yaair/network.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `yaair`

<blockquote>

## [0.3.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.2.0...yaair-v0.3.0) - 2026-05-07

### Other

- use PAT for opening PR so that workflows will run
</blockquote>

## `yaair_serde`

<blockquote>

## [0.2.1](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.2.0...yaair_serde-v0.2.1) - 2026-05-07

### Other

- use PAT for opening PR so that workflows will run
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).