### PR TITLE
chore: direnv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,15 @@
 result
 flake.lock
 *.drv
-nix-shell-* 
+nix-shell-*
 nix-build-*
+
+# direnv
+.direnv/
+.envrc
+
+# env
+.env
 
 # Created by https://www.toptal.com/developers/gitignore/api/rust,intellij
 # Edit at https://www.toptal.com/developers/gitignore?templates=rust,intellij


### PR DESCRIPTION
This gives a better dx to people using direnv and doesn't impact anyone else since the `.envrc` file is ignored.
I think this should be considered since a nix devshell is also provided in the flake, and it's very common for people using nix to also use direnv to automatically load it.

The env file is also ignored since some people prefer to split the `.envrc` (for automatic loading) from the `.env` (for variables declaration). 