### PR TITLE
chore: release

### DIFF
--- a/yaair/CHANGELOG.md
+++ b/yaair/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.3.0...yaair-v0.4.0) - 2026-05-14
+
+### Added
+
+- make network aware of the local ID and changed the serialization strategy ([#36](https://github.com/nicolasfara/yaair/pull/36))
+
 ## [0.3.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.2.0...yaair-v0.3.0) - 2026-05-07
 
 ### Other

--- a/yaair/Cargo.toml
+++ b/yaair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaair"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "Nicolas Farabegoli <nicolas.farabegoli@gmail.com>"

--- a/yaair_serde/CHANGELOG.md
+++ b/yaair_serde/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.2.1...yaair_serde-v0.2.2) - 2026-05-14
+
+### Other
+
+- updated the following local packages: yaair
+
 ## [0.2.1](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.2.0...yaair_serde-v0.2.1) - 2026-05-07
 
 ### Other

--- a/yaair_serde/Cargo.toml
+++ b/yaair_serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaair_serde"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = [
     "Nicolas Farabegoli <nicolas.farabegoli@gmail.com>"
@@ -13,7 +13,7 @@ name = "gradient"
 path = "../examples/gradient.rs"
 
 [dependencies]
-yaair = { path = "../yaair", version = "0.3.0" }
+yaair = { path = "../yaair", version = "0.4.0" }
 serde = { version = "1.0.227" }
 serde_json = { version = "1.0.145" }
 


### PR DESCRIPTION



## 🤖 New release

* `yaair`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `yaair_serde`: 0.2.1 -> 0.2.2

### ⚠ `yaair` breaking changes

```text
--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_const_removed.ron

Failed in:
  Engine::get_local_id in /tmp/.tmpFNb7GM/yaair/yaair/src/yaair/engine.rs:39

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  yaair::yaair::engine::Engine::new now takes 4 parameters instead of 5, in /tmp/.tmpFNb7GM/yaair/yaair/src/yaair/engine.rs:24

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method yaair::yaair::network::Network::get_local_id in file /tmp/.tmpFNb7GM/yaair/yaair/src/yaair/network.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `yaair`

<blockquote>

## [0.4.0](https://github.com/nicolasfara/yaair/compare/yaair-v0.3.0...yaair-v0.4.0) - 2026-05-14

### Added

- make network aware of the local ID and changed the serialization strategy ([#36](https://github.com/nicolasfara/yaair/pull/36))
</blockquote>

## `yaair_serde`

<blockquote>

## [0.2.2](https://github.com/nicolasfara/yaair/compare/yaair_serde-v0.2.1...yaair_serde-v0.2.2) - 2026-05-14

### Other

- updated the following local packages: yaair
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).